### PR TITLE
Add gist.github.com to the manifest.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Monaco Markdown Editor For GitHub",
-	"version": "0.4.2",
+	"version": "0.4.3",
 
 	"description": "This extension brings the famous Monaco editor to GitHub!",
 	"icons": {
@@ -10,11 +10,17 @@
 
 	"content_scripts": [
 		{
-			"matches": ["https://github.com/*"],
+			"matches": [
+				"https://github.com/*",
+				"https://gist.github.com/*"
+			],
 			"js": ["/dist/content-script.js"],
 			"run_at": "document_end"
 		}
 	],
-	"permissions": ["https://github.com/*"],
+	"permissions": [
+		"https://github.com/*",
+		"https://gist.github.com/*"
+	],
 	"web_accessible_resources": ["dist/*"]
 }


### PR DESCRIPTION
Just found this project after [this link from HN](https://news.ycombinator.com/item?id=26086510) and I figured that I could do some damage here.

Let's add (Gists)[https://gist.github.com] to the editors that are editable by default by Monaco.

Before:
<img width="1049" alt="Screen Shot 2021-02-10 at 11 50 54 AM" src="https://user-images.githubusercontent.com/2186874/107564254-00a55100-6b97-11eb-8f36-d89000242abb.png">


After:
<img width="1093" alt="Screen Shot 2021-02-10 at 11 52 42 AM" src="https://user-images.githubusercontent.com/2186874/107564232-fa16d980-6b96-11eb-8a44-edce0ce7e089.png">
