### PR TITLE
Add a space after user and issue autocomplete

### DIFF
--- a/src/content-script-main/GitHubCompletionController.ts
+++ b/src/content-script-main/GitHubCompletionController.ts
@@ -59,7 +59,7 @@ export class GitHubCompletionController {
 			return {
 				suggestions: data.map((s) => ({
 					label: `@${s.login} (${s.name})`,
-					insertText: `@${s.login}`,
+					insertText: `@${s.login} `,
 					filterText: `@${s.name} ${s.login}`,
 					detail: `@${s.login}`,
 					kind: this.monaco.languages.CompletionItemKind.Function,
@@ -73,7 +73,7 @@ export class GitHubCompletionController {
 				suggestions: data.suggestions.map((s) => ({
 					label: `#${s.number} (${s.title})`,
 					filterText: `#${s.title} ${s.number}`,
-					insertText: `#${s.number}`,
+					insertText: `#${s.number} `,
 					detail: `#${s.number}`,
 					kind: this.monaco.languages.CompletionItemKind.Function,
 					documentation: s.type,


### PR DESCRIPTION
I think this is the only thing that I wish this extension did that it currently does not do. I think it makes sense to have the cursor automatically insert a space after selecting the username, since that's the behavior with the vanilla comment editor in GitHub.