### PR TITLE
Fix transaprent preview

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -49,7 +49,7 @@
 			border: 2px solid black;
 			flex: 1;
 			max-width: 816px;
-			background: var(--color-bg-canvas);
+			background: var(--color-canvas-default);
 		}
 	}
 }


### PR DESCRIPTION
The variable `--color-bg-canvas` is not defined. Correct is `--color-canvas-default`

```
  --color-fg-default: #adbac7;
  --color-fg-muted: #768390;
  --color-fg-subtle: #636e7b;
  --color-fg-on-emphasis: #cdd9e5;
  --color-canvas-default: #22272e;
  --color-canvas-overlay: #2d333b;
  --color-canvas-inset: #1c2128;
  --color-canvas-subtle: #2d333b;
```

BEFORE:
![image](https://user-images.githubusercontent.com/2313018/170515454-baf77b9c-7b73-4b9d-b8bb-7276db06bbfa.png)

AFTER:
![image](https://user-images.githubusercontent.com/2313018/170515355-a7aa6a09-8e06-4e3e-9f23-b7ed9f2af80a.png)

Although honestly, I think the transparent background is siiiiiiiiick! 🤩🤩